### PR TITLE
longer zero button

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,6 @@
 			<button class="number" onclick="buttonPressed(2)">2</button>
 			<button class="number" onclick="buttonPressed(3)">3</button>
 			<button class="operator" onclick="buttonPressed('*')">×</button>
-			<button class="number" onclick="buttonPressed('')"></button>
 			<button class="number" onclick="buttonPressed(0)">0</button>
 			<button class="number" onclick="buttonPressed('.')">.</button>
 			<button class="equal" onclick="calculate()">=</button>

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
 			<button class="number" onclick="buttonPressed(2)">2</button>
 			<button class="number" onclick="buttonPressed(3)">3</button>
 			<button class="operator" onclick="buttonPressed('*')">×</button>
-			<button class="number" onclick="buttonPressed(0)">0</button>
+			<button class="number zero" onclick="buttonPressed(0)">0</button>
 			<button class="number" onclick="buttonPressed('.')">.</button>
 			<button class="equal" onclick="calculate()">=</button>
 		</div>

--- a/style.css
+++ b/style.css
@@ -43,6 +43,14 @@
 	transition: 1s;
 }
 
+.zero {
+	width: 150px;
+	border-radius: 55px;	
+	text-align: left;
+	padding-left: 30px;
+	grid-column: 1 / span 2;
+}
+
 .number:hover {
 	background-color: #737373;
 	transition: 1s;


### PR DESCRIPTION
- grid-column 1 / 2 span 2; is shorthand for grid-column-start: 1, grid-column-end: 3.
- The width makes the button itself look longer, grid-column only gave it the space.
- Border-radius makes the edges less oval despite being longer now.
- Text-align left moves the 0 symbol to the left, padding-left moves it away from the very edge.